### PR TITLE
Hyper-V settings optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Create ~/.vagrantuser for user wide configuration, e.g:
 pagrant:
   cpus: 2 # defaults to host cores / 2
   mem: 1024 # defaults to host memory / 4
+  min_mem: 1024 # hyper-v only, default mem = min_mem to turn off dynamic memory
+  differencing_disk: false # hyper-v only, defaults to true
   github:
     oauth_token: your_github_token
   sync:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,8 @@ Vagrant.configure(2) do |config|
   user_config = {
     "cpus" => cpus,
     "mem" => mem,
+    "min_mem" => mem,
+    "differencing_disk" => true,
     "sync" => {
       "type" => "rsync",
       "exclude" => []
@@ -69,8 +71,9 @@ Vagrant.configure(2) do |config|
       override.vm.box = "kmm/ubuntu-xenial64"
       vm.vmname = node.vm.hostname
       vm.cpus = user_config["cpus"]
-      vm.memory = 512
+      vm.memory = user_config["min_mem"]
       vm.maxmemory = user_config["mem"]
+      vm.differencing_disk = true
     end
 
     config.vm.provision 'Wait for unattended-upgrades', type: 'shell', 


### PR DESCRIPTION
Add support of Differencing disk (default `true`)
Add support of setting Dynamic Memory range (turn off by default, i.e. min_mem=max_mem). Static memory should be used by default to avoid problems with excessive memory usage, that ubuntu+hyper-v can not handle sometimes.