### PR TITLE
Proper disable of dynamic memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Create ~/.vagrantuser for user wide configuration, e.g:
 pagrant:
   cpus: 2 # defaults to host cores / 2
   mem: 1024 # defaults to host memory / 4
-  min_mem: 1024 # hyper-v only, default mem = min_mem to turn off dynamic memory
+  max_mem: 2048 # hyper-v only, defaults to false = turn off dynamic memory
   differencing_disk: false # hyper-v only, defaults to true
   github:
     oauth_token: your_github_token

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,7 +73,7 @@ Vagrant.configure(2) do |config|
       vm.cpus = user_config["cpus"]
       vm.memory = user_config["mem"]
       vm.maxmemory = user_config["max_mem"]
-      vm.differencing_disk = true
+      vm.differencing_disk = user_config["differencing_disk"]
     end
 
     config.vm.provision 'Wait for unattended-upgrades', type: 'shell', 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
   user_config = {
     "cpus" => cpus,
     "mem" => mem,
-    "min_mem" => mem,
+    "max_mem" => false,
     "differencing_disk" => true,
     "sync" => {
       "type" => "rsync",
@@ -71,8 +71,8 @@ Vagrant.configure(2) do |config|
       override.vm.box = "kmm/ubuntu-xenial64"
       vm.vmname = node.vm.hostname
       vm.cpus = user_config["cpus"]
-      vm.memory = user_config["min_mem"]
-      vm.maxmemory = user_config["mem"]
+      vm.memory = user_config["mem"]
+      vm.maxmemory = user_config["max_mem"]
       vm.differencing_disk = true
     end
 


### PR DESCRIPTION
Seems that setting min = max does not disable dynamic memory. 
For proper disable `vm.maxmemory` should be set to `false` (or unset). 
Dynamic memory is causing problems sometimes so it is better to be disabled by default.