### PR TITLE
Support of Symfony flex sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,47 +37,48 @@ pagrant:
   max_mem: 2048 # hyper-v only, defaults to false = turn off dynamic memory
   differencing_disk: false # hyper-v only, defaults to true
   github:
-    oauth_token: your_github_token
+    oauth_token: your_github_token # Equivalent to 'composer_github_oauth' in `extra_vars`
   sync:
-    type: parallels #defaults to rsync
-    exclude: # defaults to the list below
+    type: parallels # defaults to 'rsync'
+    exclude: # defaults to the list below. You need to provide the full list
       - .vagrant/
       - .git/
       - vendor/*
       - app/logs/*
-      - var/logs/*
+      - var/*
       - app/cache/*
-      - var/cache/*
       - app/bootstrap*
       - web/uploads/*
       - web/bundles/*
+      - public/uploads/*
+      - public/bundles/*
       - bower_components/
       - node_modules/*
+  project_path: /app # Absolute path of your project root. Default is '/app'
+  extra_vars:
+    php_fpm_version: 7.1
 ```
 
-Note: <project_name> is the name of the directory that contains the pagrant_submodule.
+Note: <project_name> is the name of the directory that contains the <pagrant_submodule>.
 E.g. if the module is located in `/home/cool_project/vagrant/` then <project_name> will be "cool_project"
 
 ### Per project configuration
 
 Per project configuration can be set by creating `<path_to_project>/<pagrant_submodule>/.vagrantuser`.
 
-E.g. `/cool_project/vagrant/.vagrantuser`:
+E.g. To customize sync exclusions create `/cool_project/vagrant/.vagrantuser`:
 
 ```yml
 pagrant:
   sync:
+    # Symfony flex app
     exclude:
       - .vagrant/
       - .git/
       - vendor/*
-      - app/logs/*
-      - var/logs/*
-      - app/cache/*
-      - var/cache/*
-      - app/bootstrap*
-      - web/uploads/*
-      - web/bundles/*
+      - var/*
+      - public/uploads/*
+      - public/bundles/*
       - bower_components/
       - node_modules/*
 ```
@@ -87,19 +88,23 @@ pagrant:
 Default configuration is optimal for common use but you are able to tweak the provisioning by passing certain vars that are used in Ansbile roles and tasks.
 You can override the values you want by defining the `extra_vars` section in `.vagrantuser`.
 
-E.g. `/cool_project/vagrant/.vagrantuser`:
+E.g. for a Symfony flex project `/cool_project/vagrant/.vagrantuser`:
 
 ```yml
 pagrant:
   extra_vars:
-    php_fpm_version: '7.2' # Define the PHP version. Default is '7.1'. Supported are 7.0, 7.1, 7.2.
+    php_fpm_version: '7.2' # Define the PHP version. Default is '7.1'.
+    nginx_sites_default_root: /app/public # Absolute path of the public dir. Default is '/app/web'.
 ```
 
-Note: For the supported vars you need to check the official documentation of the ansible roles which are listed in `<pagrant_submodule>/ansible/requirements.yml`
+Notes:
 
-**Warning: These variables are intended to be used in the initial provisioning. If you change values you might need to destroy the machine and recreate it again. Else if you try to reprovision some unexpected problems may appear. 
+ * For the supported vars you need to check the official documentation of the ansible roles which are listed in `<pagrant_submodule>/ansible/requirements.yml`
+ * Make sure `nginx_sites_default_root` points to a subdir of `project_path`
+ * Avoid changing `extra_vars` after initial provisioning. Reprovision after changes might have unexpected results
+ * Supported php versions and packages could be found here https://launchpad.net/~ondrej/+archive/ubuntu/php/+index?field.series_filter=xenial
 
-**Warning: Hot swapping of php versions is not supported! If you change `php_fpm_version` after init and run `vagrant reload --provision` the machine will fail to initialize because the old version will not be uninstalled.
+**Warning: If you change `php_fpm_version` and reprovision with `vagrant reload --provision` you will end up with multiple php versions installed. Nginx will be reconfigured to use the updated `php_fpm_version`**
 
 ## Suggestions
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,17 +41,19 @@ Vagrant.configure(2) do |config|
         ".vagrant/",
         ".git/",
         "vendor/*",
+        "var/*",
         "app/logs/*",
-        "var/logs/*",
         "app/cache/*",
-        "var/cache/*",
         "app/bootstrap*",
         "web/uploads/*",
         "web/bundles/*",
+        "public/uploads/*",
+        "public/bundles/*",
         "bower_components/",
         "node_modules/*"
       ]
     },
+    "project_path" => "/app",
     "extra_vars" => {},
     "github" => {
       "oauth_token" => ""
@@ -60,6 +62,7 @@ Vagrant.configure(2) do |config|
 
   # Backwards compatibility
   user_config["extra_vars"]["composer_github_oauth"] ||= user_config["github"]["oauth_token"]
+  user_config["extra_vars"]["project_path"] ||= user_config["project_path"]
 
   if Vagrant.has_plugin?("nugrant")
     config.user.defaults = {'pagrant' => user_config}
@@ -70,7 +73,7 @@ Vagrant.configure(2) do |config|
   config.vm.define "dev", primary: true do |node|
     node.vm.hostname = user_config["hostname"]
     node.vm.synced_folder ".", "/vagrant", type: user_config["sync"]["type"]
-    node.vm.synced_folder "..", "/app", type: user_config["sync"]["type"],
+    node.vm.synced_folder "..", user_config["extra_vars"]["project_path"], type: user_config["sync"]["type"],
       rsync__exclude: user_config["sync"]["exclude"]
 
     node.vm.provider "virtualbox" do |vm, override|
@@ -109,7 +112,7 @@ Vagrant.configure(2) do |config|
     end
 
     if Vagrant.has_plugin?("HostManager")
-        node.vm.post_up_message = "Project URL: http://" + user_config["hostname"] + "/app_dev.php"
+        node.vm.post_up_message = "Project URL: http://" + user_config["hostname"] + "/"
     end
   end
 end

--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -35,10 +35,10 @@
       - php-ast
 
     php_fpm_pools:
-      - name: default
+      - name: "default{{php_fpm_version}}"
         user: vagrant
         group: vagrant
-        listen: /var/run/php/fpm-default.sock
+        listen: "/var/run/php/fpm-{{php_fpm_version}}.sock"
         listen.owner: www-data
         listen.group: www-data
         listen.mode: "0660"
@@ -71,21 +71,23 @@
          - ssl_certificate_key "{{ ssl_certs_privkey_path }}"
          - ssl_certificate     "{{ ssl_certs_cert_path }}"
 
+    nginx_sites_default_root: "/app/web"
+
     nginx_sites:
       default:
-         - listen 80 default_server
-         - listen 443 ssl http2
-         - server_name _
-         - root /app/web
-         - fastcgi_buffers 16 16k
-         - fastcgi_buffer_size 32k
-         - "location / { try_files $uri /app.php$is_args$args; }"
-         -  location ~ ^/(app|app_dev|config|install)\.php(/|$) {
-            fastcgi_pass unix:/var/run/php/fpm-default.sock;
-            fastcgi_split_path_info ^(.+\.php)(/.*)$;
-            include fastcgi_params;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-          }
+        - listen 80 default_server
+        - listen 443 ssl http2
+        - server_name _
+        - root {{nginx_sites_default_root}}
+        - fastcgi_buffers 16 16k
+        - fastcgi_buffer_size 32k
+        -  location / { try_files $uri /app.php$is_args$args /index.php$is_args$args; }
+           location ~ ^/(app|app_dev|config|install|index)\.php(/|$) {
+           fastcgi_pass unix:/var/run/php/fpm-{{php_fpm_version}}.sock;
+           fastcgi_split_path_info ^(.+\.php)(/.*)$;
+           include fastcgi_params;
+           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+         }
 
   roles:
     - jdauphant.ssl-certs


### PR DESCRIPTION
The new symfony structure (Flex) recommends index.php as front controller and public in `/public` instead of `/web`.

+ Allow configuration of `project_path`
+ Use `nginx_site_default_root`
+ allow installing of multiple php versions with limitations. Will allow reprovision with changed php_fpm_version. The latest will be used by nginx, however the previous services will stay active.