### PR TITLE
Update NodeJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ E.g. for a Symfony flex project `/cool_project/vagrant/.vagrantuser`:
 pagrant:
   extra_vars:
     php_fpm_version: '7.2' # Define the PHP version. Default is '7.1'.
+    nodejs_version: '8.x' # Define the NodeJS major version. Default is '6.x'.
     nginx_sites_default_root: /app/public # Absolute path of the public dir. Default is '/app/web'.
 ```
 

--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -12,6 +12,8 @@
     percona_server_server_config:
       performance_schema: "off"
 
+    nodejs_version: '6.x'
+
     php_fpm_version: '7.1'
     php_fpm_apt_packages:
       - php{{php_fpm_version}}-fpm
@@ -97,12 +99,30 @@
     - dincho.elasticsearch
 
   tasks:
-    - name: Install nodejs, npm, git
-      apt: pkg={{ item }} state=installed
+    - name: Add NodeSource apt key
+      apt_key:
+        url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+        state: present
+
+    - name: Add NodeSource repositories for Node.js
+      apt_repository:
+        repo: "{{ item }}"
+        state: present
       with_items:
-       - nodejs-legacy
-       - npm
+        - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+        - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
+      register: node_repo
+
+    - name: Update apt cache if repo was added
+      apt: update_cache=yes
+      when: node_repo.changed
+
+    - name: Install nodejs, git, make
+      apt: pkg={{ item }} state=present force=yes
+      with_items:
+       - nodejs
        - git
+       - make
 
     - name: Install bower & yarn
       npm: name={{ item }} global=yes state=present

--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -118,7 +118,7 @@
       when: node_repo.changed
 
     - name: Install nodejs, git, make
-      apt: pkg={{ item }} state=present force=yes
+      apt: pkg={{ item }} state=present
       with_items:
        - nodejs
        - git


### PR DESCRIPTION
Ubuntu 16.04 ships with NodeJs v4.2.6.
Webpack now requires a newer version ">=6.11.5" and show a deprecation warning.

This PR adds the ability to choose a newer version of nodejs while setting up the environment.