### PR TITLE
Update config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(2) do |config|
     "boxes" => {
       "virtualbox" => "bento/ubuntu-16.04",
       "parallels" => "parallels/ubuntu-16.04",
-      "hyperv" => "kmm/ubuntu-xenial64",
+      "hyperv" => "bento/ubuntu-16.04",
     },
     "cpus" => cpus,
     "mem" => mem,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ Vagrant.configure(2) do |config|
         "public/uploads/*",
         "public/bundles/*",
         "bower_components/",
-        "node_modules/*"
+        "node_modules/"
       ]
     },
     "project_path" => "/app",

--- a/ansible/apt-kill.sh
+++ b/ansible/apt-kill.sh
@@ -3,4 +3,5 @@
 #  config.vm.provision 'Stop unattended-upgrades', type: 'shell', path: './ansible/apt-kill.sh'
 
 systemctl stop apt-daily.service
-systemctl kill --kill-who=all apt-daily.service
+systemctl is-active --quiet apt-daily.service && systemctl kill --kill-who=all apt-daily.service
+exit 0

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -2,10 +2,10 @@
 # but it's totally broken (out of sync tags and slow)
 - name: nbz4live.php-fpm
   src: https://github.com/NBZ4live/ansible-php-fpm
-  version: '2.0.9'
+  version: '2.0.10'
 - name: jdauphant.nginx
   src: https://github.com/jdauphant/ansible-role-nginx
-  version: 'v2.9'
+  version: 'v2.20.0'
 - name: jdauphant.ssl-certs
   src: https://github.com/jdauphant/ansible-role-ssl-certs
   version: 'v1.4'

--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -118,11 +118,12 @@
       when: node_repo.changed
 
     - name: Install nodejs, git, make
-      apt: pkg={{ item }} state=present
-      with_items:
-       - nodejs
-       - git
-       - make
+      apt:
+        pkg:
+          - nodejs
+          - git
+          - make
+        state: present
 
     - name: Install bower & yarn
       npm: name={{ item }} global=yes state=present

--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -123,6 +123,7 @@
           - nodejs
           - git
           - make
+          - unzip
         state: present
 
     - name: Install bower & yarn

--- a/ansible/setup.yml
+++ b/ansible/setup.yml
@@ -1,3 +1,3 @@
 ---
-- include: services.yml
-- include: app.yml
+- import_playbook: services.yml
+- import_playbook: app.yml


### PR DESCRIPTION
- Change default hyperv box to the officially supported by vagrant (fix not reporting the guest IP on newest hyperv)
- Update role versions
- Do not fail provision if apt-service is not running on the box
- Fix ansible depreactions (however imported roles still might show deprecation warnings)
- Ignore whole node_modules (instead of contents) from rsync, else empty dir will be created if host has non-empty dir.
- Install unzip to speedup composer installs (else it will fallback to php-zip)