### PR TITLE
Set default php version

### DIFF
--- a/ansible/app.yml
+++ b/ansible/app.yml
@@ -11,11 +11,6 @@
     - { role: kosssi.composer, become: true }
 
   tasks:
-    - name: Set default PHP version
-      command: >
-        update-alternatives --set php /usr/bin/php{{ php_fpm_version }}
-      become: yes
-
     - name: "Add {{ extra_path }} to path"
       lineinfile:
         dest: ~/.profile

--- a/ansible/app.yml
+++ b/ansible/app.yml
@@ -11,6 +11,11 @@
     - { role: kosssi.composer, become: true }
 
   tasks:
+    - name: Set default PHP version
+      command: >
+        update-alternatives --set php /usr/bin/php{{ php_fpm_version }}
+      become: yes
+
     - name: "Add {{ extra_path }} to path"
       lineinfile:
         dest: ~/.profile

--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -99,7 +99,7 @@
     - dincho.elasticsearch
 
   tasks:
-    - name: Set default PHP version
+    - name: Set default PHP version to {{php_fpm_version}}
       command: >
         update-alternatives --set php /usr/bin/php{{php_fpm_version}}
 

--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -99,6 +99,10 @@
     - dincho.elasticsearch
 
   tasks:
+    - name: Set default PHP version
+      command: >
+        update-alternatives --set php /usr/bin/php{{php_fpm_version}}
+
     - name: Add NodeSource apt key
       apt_key:
         url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"


### PR DESCRIPTION
When you re-provision with a changed php-fpm version you will end up with multiple php versions.
This task ensures that you are using the new version.