### PR TITLE
Update dincho.percona-server version

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -11,7 +11,7 @@
   version: 'v1.4'
 - name: dincho.percona-server
   src: https://github.com/dincho/ansible-percona-server
-  version: '2.0.0'
+  version: 'v2.1.0'
 - name: dincho.elasticsearch
   src: https://github.com/dincho/ansible-elasticsearch
   version: '2.0.0'


### PR DESCRIPTION
In `v2.1.0` percona-server gets installed from their repository, not Ubuntu's.