### PR TITLE
Install npm via apt

### DIFF
--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -128,6 +128,7 @@
           - git
           - make
           - unzip
+          - npm
         state: present
 
     - name: Install bower & yarn


### PR DESCRIPTION
The `Install bower & yarn` task fails because not all boxes have npm installed.