### PR TITLE
Prioritize execution of custom tasks

### DIFF
--- a/ansible/app.yml
+++ b/ansible/app.yml
@@ -25,6 +25,14 @@
         state: present
         line: 'cd {{ project_path }}'
 
+    - name: "Stat {{ project_path }}/ansible_dev.yml"
+      stat: path="{{ project_path }}/ansible_dev.yml"
+      register: projecttasks
+
+    - include: "{{ project_path }}/ansible_dev.yml"
+      tags: projecttasks
+      when: projecttasks.stat.exists == True
+
     - name: Add composer github token
       command: >
         {{ composer_path }} config --global github-oauth.github.com {{ composer_github_oauth }}
@@ -52,11 +60,3 @@
       args:
         chdir: "{{ project_path }}"
       when: composer_lock.stat.exists == True
-
-    - name: "Stat {{ project_path }}/ansible_dev.yml"
-      stat: path="{{ project_path }}/ansible_dev.yml"
-      register: projecttasks
-
-    - include: "{{ project_path }}/ansible_dev.yml"
-      tags: projecttasks
-      when: projecttasks.stat.exists == True


### PR DESCRIPTION
Running user defined tasks before the built in ones (bower, composer install) can resolve missing dependencies.

For example:
Composer packages might require an apt-package that is missing from the default config.