### PR TITLE
Update composer role

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ E.g. for a Symfony flex project `/cool_project/vagrant/.vagrantuser`:
 ```yml
 pagrant:
   extra_vars:
+    composer_version: '1.10.9' # Defines the Composer version.
     php_fpm_version: '7.2' # Define the PHP version. Default is '7.1'.
     nodejs_version: '8.x' # Define the NodeJS major version. Default is '6.x'.
     nginx_sites_default_root: /app/public # Absolute path of the public dir. Default is '/app/web'.

--- a/ansible/app.yml
+++ b/ansible/app.yml
@@ -6,9 +6,12 @@
     project_path: /app
     bower_path: bower
     extra_path: ./vendor/bin
+    composer_version: 1.10.9
+    composer_project_path: "{{ project_path }}"
+    composer_github_oauth_token: "{{ composer_github_oauth|default('') }}"
 
   roles:
-    - { role: kosssi.composer, become: true }
+    - { role: geerlingguy.composer, become: true }
 
   tasks:
     - name: "Add {{ extra_path }} to path"
@@ -24,11 +27,6 @@
         dest: ~/.profile
         state: present
         line: 'cd {{ project_path }}'
-
-    - name: Add composer github token
-      command: >
-        {{ composer_path }} config --global github-oauth.github.com {{ composer_github_oauth }}
-      when: composer_github_oauth != "" and composer_github_oauth != false
 
     - name: Stat bower.json
       stat: path="{{ project_path }}/bower.json"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -15,6 +15,6 @@
 - name: dincho.elasticsearch
   src: https://github.com/dincho/ansible-elasticsearch
   version: '2.0.0'
-- name: kosssi.composer
-  src: https://github.com/kosssi/ansible-role-composer
-  version: 'v1.6.1'
+- name: geerlingguy.composer
+  src: https://github.com/geerlingguy/ansible-role-composer
+  version: '1.7.6'


### PR DESCRIPTION
The issue:
- `kosssi.composer` now installs version 2.* (beta) of composer by default. Projects rely on version 1
- the role doesn't support versioning
- the role hasn't been maintained in 5 years

The solution:
- use a role that is maintained
- from a vendor we already use
- and has versioning