### PR TITLE
Fix default apt packages install

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The apt and npm packages listed below are required by pagrant (by dafault). This
 pagrant:
   extra_vars:
     apt_packages:
-      pkg:
+      - pkg:
         - nodejs
         - git
         - make

--- a/ansible/services.yml
+++ b/ansible/services.yml
@@ -15,7 +15,7 @@
     nodejs_version: '6.x'
 
     apt_packages:
-      pkg:
+      - pkg:
         - nodejs
         - git
         - make


### PR DESCRIPTION
The issue:
Default installation doesn't install any apt packages resulting in an `npm` missing error.

The solution:
`with_items` requires a list of items, currently `pkg:` is treated as string